### PR TITLE
Add optional parameter to configure screenshot output directory

### DIFF
--- a/src/wdio-commands-api.d.ts.stub
+++ b/src/wdio-commands-api.d.ts.stub
@@ -19,13 +19,13 @@ declare global {
         }
         interface Browser {
             logMessage: (message: string) => void;
-            logScreenshot: (message: string) => void;
+            logScreenshot: (message: string, outputDirectory?: string) => void;
             addCommand: (name: string, func:Function, force?:boolean) => void;
 
         }
         interface MultiRemoteBrowser  {
             logMessage: (message: string) => void;
-            logScreenshot: (message: string) => void;
+            logScreenshot: (message: string, outputDirectory?: string) => void;
             addCommand: (name: string, func:Function, force?:boolean) => void;
 
         }

--- a/src/wdio-commands.ts
+++ b/src/wdio-commands.ts
@@ -16,10 +16,10 @@ class Commands {
         eventReporter.logMessage(message);
     };
 
-    logScreenshot(message: string) {
+    logScreenshot(message: string, outputDirectory: string = 'reports/html-reports/screenshots/') {
         const timestamp = dayjs().utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
-        fs.ensureDirSync('reports/html-reports/screenshots/');
-        const filepath = path.join('reports/html-reports/screenshots/', timestamp + '.png');
+        fs.ensureDirSync(outputDirectory);
+        const filepath = path.join(outputDirectory, timestamp + '.png');
         //@ts-ignore
         browser.saveScreenshot(filepath);
         eventReporter.logMessage(message);


### PR DESCRIPTION
Hi Rich, first of all, a sincere thank you for all of your wdio packages!

I'd like to be able to define the screenshot output directory for the logScreenshot command. I use different directory structures for my reports and would like to keep the screenshots grouped with their respective test runs.

I updated the type definitions in the .stub file but it looks like you'd have to update the definitions in ./lib/*.d.ts which aren't in git, unless I'm missing something. Thanks for taking a look.

All the best,
-Alex